### PR TITLE
Add OpenAI version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ cd sumitt
 pip install -r requirements.txt
 ```
 
+This project relies on the new `openai` Python library (version `1.0.0` or
+higher), which is specified in `requirements.txt`.
+
 Make sure you have **Tesseract OCR** installed on your machine:
 
 #### Windows:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-openai
+openai>=1.0.0
 pytesseract
 pillow
 twilio


### PR DESCRIPTION
## Summary
- specify `openai>=1.0.0` in requirements
- note the new library requirement in README

## Testing
- `python -m py_compile summarize.py helpers/*.py`
- `pip install --disable-pip-version-check --no-cache-dir openai==1.0.0`

------
https://chatgpt.com/codex/tasks/task_e_684f1a2edfbc832eaecc6b4180a33258